### PR TITLE
Adding support for short-term tokens and forgot password flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ The various variables are defined as follows:
 - `DATABASE_URL` = The URL string for your db connection. For example: `postgres://user:pass@example.com:5432/dbname`
 - `DATABASE_SCHEMA` = Your local database schema. Postgres default is `public`.
 - `JWT_KEY` = A secret value to generate JWT's locally. 
+- `SMTP_HOST` = hostname for the SMTP server used to send notification emails
+- `SMTP_PORT` = port number for the SMTP server used to send notification emails
+- `SMTP_USER` = username for the SMTP server used to send notification emails
+- `SMTP_PASSWORD` = password for the SMTP server used to send notification emails
 - `BYPASS_LOGIN` = _optional_  Allows you to hit the endpoints locally without having to login. If you wish to bypass the login process during local dev, set this to `true`.
 
 _We do not recommend using the default options for PostgreSQL. The above values are provided as examples. It is more secure to create your own credentials._

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
   db:
     image: postgres
     restart: always
+    ports:
+      - '5432:5432'
     environment:
       - POSTGRES_USER=${DATABASE_USER}
       - POSTGRES_PASSWORD=${DATABASE_PASSWORD}

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -96,6 +96,37 @@
         }
       }
     },
+    "/user/forgotpassword/{email}" : {
+      "post" : {
+        "tags" : [ "user" ],
+        "summary" : "sends a reset password email",
+        "description" : "The forgot password endpoint.",
+        "parameters" : [ {
+          "in" : "path",
+          "name" : "email",
+          "schema" : {
+            "type" : "string",
+            "format" : "email"
+          },
+          "required" : true,
+          "description" : "email of the user"
+        }],
+        "responses" : {
+          "200" : {
+            "description" : "Reset password email sent"
+          },
+          "404" : {
+            "description" : "User not found by email address provided"
+          },
+          "422" : {
+            "description" : "Invalid input"
+          },
+          "500" : {
+            "description" : "Server error"
+          }
+        }
+      }
+    },
     "/user" : {
       "post" : {
         "tags" : [ "user" ],

--- a/mail_templates/forgot_password_html.njk
+++ b/mail_templates/forgot_password_html.njk
@@ -1,0 +1,19 @@
+<h1>Reset Your Password</h1>
+
+<p>Need to reset your password? No Problem! Just click the button below and you'll be on your way. If you did not make this request, please ignore this email.</p>
+
+<table width="100%" cellspacing="0" cellpadding="0">
+  <tr>
+      <td>
+          <table cellspacing="0" cellpadding="0">
+              <tr>
+                  <td style="border-radius: 2px;" bgcolor="#ED2939">
+                      <a href="{{ emailResetLink }}" target="_blank" style="padding: 8px 12px; border: 1px solid #ED2939;border-radius: 2px;font-family: Helvetica, Arial, sans-serif;font-size: 14px; color: #ffffff;text-decoration: none;font-weight:bold;display: inline-block;">
+                          Reset Your Password             
+                      </a>
+                  </td>
+              </tr>
+          </table>
+      </td>
+  </tr>
+</table>

--- a/mail_templates/forgot_password_text.njk
+++ b/mail_templates/forgot_password_text.njk
@@ -1,0 +1,5 @@
+Reset Your Password
+
+Need to reset your password? No Problem! Just click the link below and you'll be on your way. If you did not make this request, please ignore this email.
+
+{{ emailResetLink }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2356,6 +2356,11 @@
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
     },
+    "a-sync-waterfall": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
+      "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA=="
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -2598,6 +2603,11 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
       "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
       "dev": true
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -7334,6 +7344,11 @@
         }
       }
     },
+    "nodemailer": {
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.4.6.tgz",
+      "integrity": "sha512-/kJ+FYVEm2HuUlw87hjSqTss+GU35D4giOpdSfGp7DO+5h6RlJj7R94YaYHOkoxu1CSaM0d3WRBtCzwXrY6MKA=="
+    },
     "nodemon": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.2.tgz",
@@ -7403,6 +7418,24 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "requires": {
         "path-key": "^2.0.0"
+      }
+    },
+    "nunjucks": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.1.tgz",
+      "integrity": "sha512-LYlVuC1ZNSalQQkLNNPvcgPt2M9FTY9bs39mTCuFXtqh7jWbYzhDlmz2M6onPiXEhdZo+b9anRhc+uBGuJZ2bQ==",
+      "requires": {
+        "a-sync-waterfall": "^1.0.0",
+        "asap": "^2.0.3",
+        "chokidar": "^3.3.0",
+        "commander": "^3.0.2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+          "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
+        }
       }
     },
     "nyc": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bmore-responsive",
   "version": "1.0.0",
   "description": "An emergency response API",
-  "main": "/src/app.js",
+  "main": "src/index.js",
   "directories": {
     "doc": "docs"
   },
@@ -44,7 +44,9 @@
     "lodash": "^4.17.15",
     "mocha": "7.1.1",
     "morgan": "1.9.1",
+    "nodemailer": "^6.4.6",
     "nodemon": "2.0.2",
+    "nunjucks": "^3.2.1",
     "pg": "7.18.2",
     "random-words": "1.1.0",
     "sequelize": "5.21.5",

--- a/sequelize/data/user.json
+++ b/sequelize/data/user.json
@@ -8,5 +8,10 @@
         "email": "test@test.test",
         "password": "test",
         "roles": [1]
+    },
+    {
+        "email": "gnboorse@gmail.com",
+        "password": "test",
+        "roles": [1]
     }
 ]

--- a/sequelize/data/user.json
+++ b/sequelize/data/user.json
@@ -8,10 +8,5 @@
         "email": "test@test.test",
         "password": "test",
         "roles": [1]
-    },
-    {
-        "email": "gnboorse@gmail.com",
-        "password": "test",
-        "roles": [1]
     }
 ]

--- a/src/email/index.js
+++ b/src/email/index.js
@@ -1,0 +1,48 @@
+import nodemailer from "nodemailer";
+import nunjucks from "nunjucks";
+
+const transporter = nodemailer.createTransport({
+  host: process.env.SMTP_HOST,
+  port: process.env.SMTP_PORT,
+  secure: true,
+  auth: {
+    user: process.env.SMTP_USER,
+    pass: process.env.SMTP_PASSWORD
+  }
+});
+
+/**
+ * Generic email send function
+ * @param {string} to address to send mail to
+ * @param {string} subject email subject
+ * @param {string} html  html text of the email
+ * @param {string} text  plain text of the email
+ */
+const sendMail = async (to, subject, html, text) => {
+  let info = await transporter.sendMail({
+    from: `"Healthcare Roll Call" <${process.env.SMTP_USER}>`, // sender address
+    to, // list of receivers
+    subject, // Subject line
+    text, // plain text body
+    html // html body
+  });
+  console.log("Email sent: %s", info.messageId);
+};
+
+/**
+ * Send a forgot password email.
+ * @param {string} userEmail email address of the user we're sending to
+ * @param {string} resetPasswordToken temporary token for the reset password link
+ */
+const sendForgotPassword = async (userEmail, resetPasswordToken) => {
+  const emailResetLink = `https://healthcarerollcall.org/reset/${resetPasswordToken}`;
+  await sendMail(
+    userEmail,
+    "Password Reset - Healthcare Roll Call",
+    nunjucks.render("forgot_password_html.njk", { emailResetLink }),
+    nunjucks.render("forgot_password_text.njk", { emailResetLink })
+  );
+  return true;
+};
+
+export default { sendForgotPassword };

--- a/src/email/index.js
+++ b/src/email/index.js
@@ -4,7 +4,7 @@ import nunjucks from "nunjucks";
 const transporter = nodemailer.createTransport({
   host: process.env.SMTP_HOST,
   port: process.env.SMTP_PORT,
-  secure: true,
+  requireTLS: true,
   auth: {
     user: process.env.SMTP_USER,
     pass: process.env.SMTP_PASSWORD

--- a/src/index.js
+++ b/src/index.js
@@ -32,11 +32,6 @@ app.use(async (req, res, next) => {
 		models
 	};
 
-	/** @todo add some checks for auth tokens, etc */
-	// req.context.me = {
-	// 	id: 'abc-123'
-	// };
-
 	next();
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import requestId from 'express-request-id';
 import helmet from 'helmet';
 import morgan from 'morgan';
 import swaggerUi from 'swagger-ui-express';
+import nunjucks from 'nunjucks';
 
 import swaggerDocument from '../docs/swagger/swagger.json';
 import models, { sequelize } from './models';
@@ -16,6 +17,8 @@ const app = express();
 const swaggerOptions = {
 	customCss: '.swagger-ui .topbar { display: none }'
 };
+
+nunjucks.configure('mail_templates', { autoescape: true });
 
 // Third-party middleware
 app.use(requestId());

--- a/src/routes/contact.js
+++ b/src/routes/contact.js
@@ -3,26 +3,23 @@ import validator from 'validator';
 import utils from '../utils';
 
 const router = new Router();
+router.use(utils.authMiddleware)
 
 // Gets all contacts.
 router.get('/', async (req, res) => {
 	let code;
 	let message;
 	try {
-		if (await utils.validateToken(req)) {
-			const contacts = await req.context.models.Contact.findAll({
-			});
+		const contacts = await req.context.models.Contact.findAll({
+		});
 
-			code = 200;
-			message = {
-				_meta: {
-					total: contacts.length
-				},
-				results: contacts
-			};
-		} else {
-			code = 401;
-		}
+		code = 200;
+		message = {
+			_meta: {
+				total: contacts.length
+			},
+			results: contacts
+		};
 	} catch (e) {
 		console.error(e);
 		code = 500;
@@ -36,21 +33,17 @@ router.get('/:contact_id', async (req, res) => {
 	let code;
 	let message;
 	try {
-		if (await utils.validateToken(req)) {
-			if (validator.isUUID(req.params.contact_id)) {
-				const contact = await req.context.models.Contact.findOne({
-					where: {
-						id: req.params.contact_id
-					},
-				});
+		if (validator.isUUID(req.params.contact_id)) {
+			const contact = await req.context.models.Contact.findOne({
+				where: {
+					id: req.params.contact_id
+				},
+			});
 
-				code = 200;
-				message = contact;
-			} else {
-				code = 422;
-			}
+			code = 200;
+			message = contact;
 		} else {
-			code = 401;
+			code = 422;
 		}
 	} catch (e) {
 		console.error(e);
@@ -65,18 +58,14 @@ router.post('/', async (req, res) => {
 	let code;
 	let message;
 	try {
-		if (await utils.validateToken(req)) {
-			if (req.body.name !== undefined) {
-				const { name, phone, email, UserId, EntityId } = req.body;
-				const contact = await req.context.models.Contact.create({ name, email, phone, UserId, EntityId });
+		if (req.body.name !== undefined) {
+			const { name, phone, email, UserId, EntityId } = req.body;
+			const contact = await req.context.models.Contact.create({ name, email, phone, UserId, EntityId });
 
-				code = 200;
-				message = contact.id + ' created';
-			} else {
-				code = 422;
-			}
+			code = 200;
+			message = contact.id + ' created';
 		} else {
-			code = 401;
+			code = 422;
 		}
 	} catch (e) {
 		console.error(e);
@@ -91,39 +80,36 @@ router.put('/', async (req, res) => {
 	let code;
 	let message;
 	try {
-		if (await utils.validateToken(req)) {
-			if (validator.isUUID(req.body.id)) {
-				const { id, name, phone, email, UserId, EntityId } = req.body;
+		if (validator.isUUID(req.body.id)) {
+			const { id, name, phone, email, UserId, EntityId } = req.body;
 
-				/** @todo validate emails */
-				// Validating emails 
-				// if (await !utils.validateEmails(email)) res.status(500).send('Server error');
+			/** @todo validate emails */
+			// Validating emails 
+			// if (await !utils.validateEmails(email)) res.status(500).send('Server error');
 
-				const contact = await req.context.models.Contact.findOne({
-					where: {
-						id: id
-					}
-				});
+			const contact = await req.context.models.Contact.findOne({
+				where: {
+					id: id
+				}
+			});
 
-				if (!contact) return utils.response(res, 400, message);
+			if (!contact) return utils.response(res, 400, message);
 
-				contact.name = (name) ? name : contact.name;
-				contact.phone = (phone) ? phone : contact.phone;
-				contact.email = (email) ? email : contact.email;
-				contact.UserId = (UserId) ? UserId : contact.UserId;
-				contact.EntityId = (EntityId) ? EntityId : contact.EntityId;
-				contact.updatedAt = new Date();
+			contact.name = (name) ? name : contact.name;
+			contact.phone = (phone) ? phone : contact.phone;
+			contact.email = (email) ? email : contact.email;
+			contact.UserId = (UserId) ? UserId : contact.UserId;
+			contact.EntityId = (EntityId) ? EntityId : contact.EntityId;
+			contact.updatedAt = new Date();
 
-				await contact.save();
+			await contact.save();
 
-				code = 200;
-				message = contact.id + ' updated';
-			} else {
-				code = 422;
-			}
+			code = 200;
+			message = contact.id + ' updated';
 		} else {
-			code = 401;
+			code = 422;
 		}
+	
 	} catch (e) {
 		console.error(e);
 		code = 500;
@@ -137,22 +123,18 @@ router.delete('/:contact_id', async (req, res) => {
 	let code;
 	let message;
 	try {
-		if (await utils.validateToken(req, res)) {
-			if (validator.isUUID(req.params.contact_id)) {
-				const contact = await req.context.models.Contact.findOne({
-					where: {
-						id: req.params.contact_id
-					}
-				});
-				await contact.destroy();
+		if (validator.isUUID(req.params.contact_id)) {
+			const contact = await req.context.models.Contact.findOne({
+				where: {
+					id: req.params.contact_id
+				}
+			});
+			await contact.destroy();
 
-				code = 200;
-				message = req.params.contact_id + ' deleted';
-			} else {
-				code = 422;
-			}
+			code = 200;
+			message = req.params.contact_id + ' deleted';
 		} else {
-			code = 401;
+			code = 422;
 		}
 	} catch (e) {
 		console.error(e);

--- a/src/routes/entity.js
+++ b/src/routes/entity.js
@@ -3,40 +3,37 @@ import validator from 'validator';
 import utils from '../utils';
 
 const router = new Router();
+router.use(utils.authMiddleware)
 
 // Gets all entities.
 router.get('/', async (req, res) => {
 	let code;
 	let message;
 	try {
-		if (await utils.validateToken(req, res)) {
-			const entities = await req.context.models.Entity.findAll({
-			});
+		const entities = await req.context.models.Entity.findAll({
+		});
 
-			for (let entity of entities) {
-				entity.dataValues.contacts = []
+		for (let entity of entities) {
+			entity.dataValues.contacts = []
 
-				const contacts = await req.context.models.Entity.findContacts(entity.id);
+			const contacts = await req.context.models.Entity.findContacts(entity.id);
 
-				if (contacts) {
-					for (let contact of contacts) {
-						entity.dataValues.contacts.push({
-							contact
-						});
-					}
+			if (contacts) {
+				for (let contact of contacts) {
+					entity.dataValues.contacts.push({
+						contact
+					});
 				}
 			}
-
-			code = 200;
-			message = {
-				_meta: {
-					total: entities.length
-				},
-				results: entities
-			};
-		} else {
-			code = 401;
 		}
+
+		code = 200;
+		message = {
+			_meta: {
+				total: entities.length
+			},
+			results: entities
+		};
 	} catch (e) {
 		console.error(e);
 		code = 500;
@@ -50,32 +47,28 @@ router.get('/:entity_id', async (req, res) => {
 	let code;
 	let message;
 	try {
-		if (await utils.validateToken(req, res)) {
-			if (validator.isUUID(req.params.entity_id)) {
-				const entity = await req.context.models.Entity.findOne({
-					where: {
-						id: req.params.entity_id
-					}
-				});
-				entity.dataValues.contacts = [];
-
-				const contacts = await req.context.models.Entity.findContacts(req.params.entity_id);
-
-				if (contacts) {
-					for (let contact of contacts) {
-						entity.dataValues.contacts.push({
-							contact
-						});
-					}
+		if (validator.isUUID(req.params.entity_id)) {
+			const entity = await req.context.models.Entity.findOne({
+				where: {
+					id: req.params.entity_id
 				}
+			});
+			entity.dataValues.contacts = [];
 
-				code = 200;
-				message = entity;
-			} else {
-				code = 422;
+			const contacts = await req.context.models.Entity.findContacts(req.params.entity_id);
+
+			if (contacts) {
+				for (let contact of contacts) {
+					entity.dataValues.contacts.push({
+						contact
+					});
+				}
 			}
+
+			code = 200;
+			message = entity;
 		} else {
-			code = 401;
+			code = 422;
 		}
 	} catch (e) {
 		console.error(e);
@@ -90,28 +83,24 @@ router.post('/', async (req, res) => {
 	let code;
 	let message;
 	try {
-		if (await utils.validateToken(req, res)) {
-			if (req.body.name !== undefined) {
-				let { name, address, phone, email, checkIn } = req.body;
+		if (req.body.name !== undefined) {
+			let { name, address, phone, email, checkIn } = req.body;
 
-				if (!checkIn) {
-					checkIn = {
-						_meta: {
-							total: 0
-						},
-						checkIns: []
-					}
+			if (!checkIn) {
+				checkIn = {
+					_meta: {
+						total: 0
+					},
+					checkIns: []
 				}
-
-				const entity = await req.context.models.Entity.create({ name, address, email, phone, checkIn });
-
-				code = 200;
-				message = entity.id + ' created';
-			} else {
-				code = 422;
 			}
+
+			const entity = await req.context.models.Entity.create({ name, address, email, phone, checkIn });
+
+			code = 200;
+			message = entity.id + ' created';
 		} else {
-			code = 401;
+			code = 422;
 		}
 	} catch (e) {
 		console.error(e);
@@ -126,63 +115,60 @@ router.put('/', async (req, res) => {
 	let code;
 	let message;
 	try {
-		if (await utils.validateToken(req, res)) {
-			if (validator.isUUID(req.body.id)) {
-				let { id, name, address, phone, email, checkIn } = req.body;
+		if (validator.isUUID(req.body.id)) {
+			let { id, name, address, phone, email, checkIn } = req.body;
 
-				/** @todo validate emails */
-				// Validating emails 
-				// if (await !utils.validateEmails(email)) res.status(500).send('Server error');
+			/** @todo validate emails */
+			// Validating emails 
+			// if (await !utils.validateEmails(email)) res.status(500).send('Server error');
 
-				let entity = await req.context.models.Entity.findOne({
-					where: {
-						id: id
-					}
-				});
+			let entity = await req.context.models.Entity.findOne({
+				where: {
+					id: id
+				}
+			});
 
-				entity.name = (name) ? name : entity.name;
-				entity.address = (address) ? address : entity.address;
-				entity.phone = (phone) ? phone : entity.phone;
-				entity.email = (email) ? email : entity.email;
-				/** @todo validate checkIn JSON */
-				if (entity.checkIn === null && checkIn) {
-					const checkIns = {
-						_meta: {
-							total: 1
-						},
-						checkIns: [
-							checkIn
-						]
-					}
-
-					entity.checkIn = checkIns;
-				} else if (entity.checkIn !== null && checkIn) {
-					let checkIns = entity.checkIn.checkIns;
-					checkIns.push(checkIn);
-					let total = entity.checkIn._meta.total + 1
-
-					const update = {
-						_meta: {
-							total: total
-						},
-						checkIns: checkIns
-					}
-
-					entity.checkIn = update;
+			entity.name = (name) ? name : entity.name;
+			entity.address = (address) ? address : entity.address;
+			entity.phone = (phone) ? phone : entity.phone;
+			entity.email = (email) ? email : entity.email;
+			/** @todo validate checkIn JSON */
+			if (entity.checkIn === null && checkIn) {
+				const checkIns = {
+					_meta: {
+						total: 1
+					},
+					checkIns: [
+						checkIn
+					]
 				}
 
-				entity.updatedAt = new Date();
+				entity.checkIn = checkIns;
+			} else if (entity.checkIn !== null && checkIn) {
+				let checkIns = entity.checkIn.checkIns;
+				checkIns.push(checkIn);
+				let total = entity.checkIn._meta.total + 1
 
-				await entity.save();
+				const update = {
+					_meta: {
+						total: total
+					},
+					checkIns: checkIns
+				}
 
-				code = 200;
-				message = entity.id + ' updated';
-			} else {
-				code = 422;
+				entity.checkIn = update;
 			}
+
+			entity.updatedAt = new Date();
+
+			await entity.save();
+
+			code = 200;
+			message = entity.id + ' updated';
 		} else {
-			code = 401;
+			code = 422;
 		}
+	
 	} catch (e) {
 		console.error(e);
 		code = 500;
@@ -196,22 +182,18 @@ router.delete('/:entity_id', async (req, res) => {
 	let code;
 	let message;
 	try {
-		if (await utils.validateToken(req, res)) {
-			if (validator.isUUID(req.params.entity_id)) {
-				const entity = await req.context.models.Entity.findOne({
-					where: {
-						id: req.params.entity_id
-					}
-				});
-				await entity.destroy();
+		if (validator.isUUID(req.params.entity_id)) {
+			const entity = await req.context.models.Entity.findOne({
+				where: {
+					id: req.params.entity_id
+				}
+			});
+			await entity.destroy();
 
-				code = 200;
-				message = req.params.entity_id + ' deleted';
-			} else {
-				code = 422;
-			}
+			code = 200;
+			message = req.params.entity_id + ' deleted';
 		} else {
-			code = 401;
+			code = 422;
 		}
 	} catch (e) {
 		console.error(e);

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -49,9 +49,10 @@ router.post('/forgotpassword/:email', async(req, res) => {
 				await email.sendForgotPassword(user.email, temporaryToken);
 
 				code = 200;
-				message = `Password reset email sent successfully for ${user.email}`;
+				message = `Password reset email sent`;
 			} else {
-				code = 404;
+				code = 200;
+				message = `Password reset email sent`;
 			}
 		} else {
 			code = 422;

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -43,7 +43,7 @@ router.post('/forgotpassword/:email', async(req, res) => {
 			});
 			if (user) {
 				// short-lived temporary token that only lasts one hour
-				const temporaryToken = await User.getToken(user.id, '1h');
+				const temporaryToken = await req.context.models.User.getToken(user.id, '1h');
 
 				// send forgot password email
 				await email.sendForgotPassword(user.email, temporaryToken);

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -30,29 +30,25 @@ router.post('/login', async (req, res) => {
 });
 
 // Gets all users.
-router.get('/', async (req, res) => {
+router.get('/', utils.authMiddleware, async (req, res) => {
 	let code;
 	let message;
 	try {
-		if (await utils.validateToken(req)) {
-			const users = await req.context.models.User.findAll({
-				attributes: ['id', 'email', 'roles', 'displayName', 'phone', 'createdAt', 'updatedAt']
-			});
+		const users = await req.context.models.User.findAll({
+			attributes: ['id', 'email', 'roles', 'displayName', 'phone', 'createdAt', 'updatedAt']
+		});
 
-			for (const user of users) {
-				if(user.roles) user.roles = await req.context.models.UserRole.findRoles(user.roles);
-			}
-
-			code = 200;
-			message = {
-				_meta: {
-					total: users.length
-				},
-				results: users
-			};
-		} else {
-			code = 401;
+		for (const user of users) {
+			if(user.roles) user.roles = await req.context.models.UserRole.findRoles(user.roles);
 		}
+
+		code = 200;
+		message = {
+			_meta: {
+				total: users.length
+			},
+			results: users
+		};
 	} catch (e) {
 		console.error(e);
 		code = 500;
@@ -62,31 +58,27 @@ router.get('/', async (req, res) => {
 });
 
 // Gets a specific user.
-router.get('/:email', async (req, res) => {
+router.get('/:email', utils.authMiddleware, async (req, res) => {
 	let code;
 	let message;
 	try {
-		if (await utils.validateToken(req)) {
-			if (validator.isEmail(req.params.email)) {
-				const user = await req.context.models.User.findOne({
-					where: {
-						email: req.params.email
-					},
-					attributes: ['id', 'email', 'roles', 'displayName', 'phone', 'createdAt', 'updatedAt']
-				});
-				if (user.roles) {
-					user.roles = await req.context.models.UserRole.findRoles(user.roles);
-					/** @todo add contact info for users */
-					// user.dataValues.contact = await req.context.models.Contact.findByUserId(user.id);
-				}
-
-				code = 200;
-				message = user;
-			} else {
-				code = 422;
+		if (validator.isEmail(req.params.email)) {
+			const user = await req.context.models.User.findOne({
+				where: {
+					email: req.params.email
+				},
+				attributes: ['id', 'email', 'roles', 'displayName', 'phone', 'createdAt', 'updatedAt']
+			});
+			if (user.roles) {
+				user.roles = await req.context.models.UserRole.findRoles(user.roles);
+				/** @todo add contact info for users */
+				// user.dataValues.contact = await req.context.models.Contact.findByUserId(user.id);
 			}
+
+			code = 200;
+			message = user;
 		} else {
-			code = 401;
+			code = 422;
 		}
 	} catch (e) {
 		console.error(e);
@@ -119,29 +111,25 @@ router.post('/', async (req, res) => {
 });
 
 // Updates any user.
-router.put('/', async (req, res) => {
+router.put('/', utils.authMiddleware, async (req, res) => {
 	let code;
 	let message;
 	try {
-		if (await utils.validateToken(req)) {
-			if (validator.isEmail(req.body.email)) {
-				/** @todo add email and phone update options */
-				const { email, password } = req.body;
-				const user = await req.context.models.User.findOne({
-					where: {
-						email
-					}
-				});
-				user.password = password;
-				await user.save();
+		if (validator.isEmail(req.body.email)) {
+			/** @todo add email and phone update options */
+			const { email, password } = req.body;
+			const user = await req.context.models.User.findOne({
+				where: {
+					email
+				}
+			});
+			user.password = password;
+			await user.save();
 
-				code = 200;
-				message = user.email + ' updated';
-			} else {
-				code = 422;
-			}
+			code = 200;
+			message = user.email + ' updated';
 		} else {
-			code = 401;
+			code = 422;
 		}
 	} catch (e) {
 		console.error(e);
@@ -152,27 +140,23 @@ router.put('/', async (req, res) => {
 });
 
 // Deletes a user.
-router.delete('/:email', async (req, res) => {
+router.delete('/:email', utils.authMiddleware, async (req, res) => {
 	let code;
 	let message;
 	try {
-		if (await utils.validateToken(req)) {
-			if (validator.isEmail(req.params.email)) {
-				const user = await req.context.models.User.findOne({
-					where: {
-						email: req.params.email
-					}
-				});
-				await user.destroy();
+		if (validator.isEmail(req.params.email)) {
+			const user = await req.context.models.User.findOne({
+				where: {
+					email: req.params.email
+				}
+			});
+			await user.destroy();
 
-				code = 200;
-				message = req.params.email + ' deleted';
-			} else {
-				code = 422;
-			} 
+			code = 200;
+			message = req.params.email + ' deleted';
 		} else {
-			code = 401;
-		}
+			code = 422;
+		} 
 	} catch (e) {
 		console.error(e);
 		code = 500;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -49,6 +49,21 @@ const validateToken = async (req) => {
 	// res.status(401).send('Unauthorized');
 };
 
+/**
+ * Middleware function used to validate a user token
+ * @param {*} req the request object
+ * @param {*} res the response object
+ * @param {*} next the next handler in the chain
+ */
+const authMiddleware = async (req, res, next) => {
+	if (await validateToken(req)) {
+		next();
+	} else {
+		response(res, 401, "");
+	}
+
+}
+
 const response = (res, code, message) => {
 	const codes = {
 		200: message,
@@ -96,7 +111,7 @@ const validateEmails = async emails => {
 
 export default {
 	formatTime,
-	validateToken,
+	authMiddleware,
 	response,
 	encryptPassword,
 	validateEmails

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -51,6 +51,7 @@ const validateToken = async (req) => {
 
 /**
  * Middleware function used to validate a user token
+ * 
  * @param {*} req the request object
  * @param {*} res the response object
  * @param {*} next the next handler in the chain

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -32,21 +32,15 @@ const formatTime = seconds => {
  * @return {Boolean}
  */
 const validateToken = async (req) => {
-	// if (process.env.BYPASS_LOGIN) {
-	// 	return true;
-	// }
-
 	console.log(req.headers.token)
 
 	const authorized = await req.context.models.User.validateToken(req.headers.token);
-
 	if (authorized || process.env.BYPASS_LOGIN) {
+		req.context.me = authorized; // add user object to context
 		return true;
 	} 
 	
 	return false;
-
-	// res.status(401).send('Unauthorized');
 };
 
 /**


### PR DESCRIPTION
# Description

This PR adds support for temporary tokens that can be used for the forgot password flow (and other single-use auth use cases).

I did some light refactoring related to how tokens are generated, validated, and used.

The forgot password email logic has been added to the `/user/forgotpassword/{email}` endpoint. Email templates are located in the `mail_templates/` directory with templating provded by [nunjuck](https://mozilla.github.io/nunjucks/getting-started.html)

resolves #75 
resolves #71 

## Related PRs

No related PRs

## Todos

- [ ] Tests
- [x] Documentation

## Deploy Notes

In order to deploy this, we will need to specify the `SMTP_HOST`, `SMTP_PORT`, `SMTP_URL`, and `SMTP_PASSWORD` environment variables
