### PR TITLE
Updated swagger.json, code, and tests related to deleting user roles

### DIFF
--- a/src/routes/user-role.js
+++ b/src/routes/user-role.js
@@ -82,12 +82,14 @@ router.post('/delete', async (req, res) => {
       removed = await e.removePolicy(...p)
 
       if (removed) {
-        response.setMessage('policy deleted')
+        response.setMessage('Policy deleted')
       } else {
-        response.setCode(400)
+	response.setCode(422)
+        response.setMessage('Request inconsistent with existing casbin policy')
       }
     } else {
       response.setCode(400)
+      response.setMessage('Request does not inclue required parameters')
     }
   } catch (e) {
     console.error(e)

--- a/src/tests/userRole.routes.spec.js
+++ b/src/tests/userRole.routes.spec.js
@@ -55,7 +55,7 @@ describe('User roles positive tests', function() {
       .expect(200)
       .end((err, res) => {
         if (err) return done(err)
-        expect(res.text).to.equal('policy deleted')
+        expect(res.text).to.equal('Policy deleted')
         done()
       })
   })
@@ -82,7 +82,7 @@ describe('User roles positive tests', function() {
       .expect(400)
       .end((err, res) => {
         if (err) return done(err)
-        expect(res.text).to.equal('Bad Request')
+        expect(res.text).to.equal('Request does not inclue required parameters')
         done()
       })
   })

--- a/swagger.json
+++ b/swagger.json
@@ -3,12 +3,12 @@
   "servers": [
     {
       "description": "localhost",
-      "url": "http://localhost:3000"
+      "url": "http://localhost:3000/"
     }
   ],
   "info": {
     "description": "An emergency response and contact management API.",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "title": "Bmore Responsive",
     "contact": {
       "email": "hello@codeforbaltimore.org"
@@ -513,7 +513,7 @@
           "userRole"
         ],
         "summary": "deletes a single system user role",
-        "description": "By sending a valid payload you can delete a user role.",
+        "description": "By sending a valid payload you can delete a user role. Note that this is not an idempotent operation. You can't delete the same role twice. To create a role use POST /userRole.",
         "parameters": [
           {
             "in": "header",
@@ -539,11 +539,11 @@
                 "properties": {
                   "role": {
                     "type": "string",
-                    "example": "test"
+                    "example": "user"
                   },
                   "path": {
                     "type": "string",
-                    "example": "/test"
+                    "example": "/entity"
                   },
                   "method": {
                     "type": "string",
@@ -556,13 +556,16 @@
         },
         "responses": {
           "200": {
-            "description": "policy deleted"
+            "description": "Policy deleted"
           },
+	  "400": {
+            "description": "Request does not inclue required parameters"
+	  },
           "401": {
             "description": "Unauthorized"
           },
           "422": {
-            "description": "Invalid input"
+            "description": "All fields are present but they contain values which are inconsistent with the current casbin policy"
           },
           "500": {
             "description": "Server error"


### PR DESCRIPTION
# Description

Addresses [issue-344](https://github.com/CodeForBaltimore/Bmore-Responsive/issues/344) 

In swagger.json, the body configured by default for the "POST /userRole/delete" endpoint contained a user role that didn't exist in the default casbin policy. If the user tried to run this request using swaggerUI the request failed because the policy had not yet been created. 

To fix this I changed the default body to match a policy which exists by default in casbin, added more detailed response messages in src/routes/user-role.js, and updated the description in swagger.json to explain that if a policy doesn't exist then it must be created before it can be deleted. I also changed the corresponding tests so that they pass but didn't add any new tests.

Alternatively, I considered leaving the body of the "POST /userRole/delete" request in swagger unchanged so that it matched the corresponding creation request (POST /userRole). Updating the description would tell the user that the latter needs to be used first. Whoever reviews this, I'd really appreciate a sanity check on that.

## Deploy Notes

```sh
docker-compose up -d --build
```

## Steps to Test or Reproduce

Run npm test

```sh
docker-compose up -d --build
docker ps
docker exec -it <insert API container ID here> /bin/sh
/usr/src# npm test
```
Manually experiment by sending different requests to the /userRole/delete endpoint using swagger UI which by default is hosted at localhost:3001/api-docs

## Impacted Areas in Application

List general components of the application that this PR will affect:

- /userRole/delete endpoint
