### PR TITLE
Create CI Pipeline with Github actions that lints, builds and installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,6 @@ jobs:
 
       - name: Test
         run: |
-          docker exec bmore-responsive-api-1 npm test
+          docker exec bmore-responsive_api_1 npm test
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: Bmore Responsive CI
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test
+
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,23 +35,9 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    needs: audit
 
     steps:
       - uses: actions/checkout@v2
-
-      - name: Cache node modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-node-modules
-        with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
 
       - name: install eslint
         run: npm install eslint
@@ -68,16 +54,15 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: lint
+    needs:
+      - audit
+      - lint
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Build docker stack
         run: docker-compose up -d --build
-
-      - name: Show running images
-        run: docker images
 
       - name: Save docker images
         run: |
@@ -110,6 +95,7 @@ jobs:
 
       - name: Test
         run: |
+          sleep 15 # wait for containers to set up
           docker exec bmore-responsive-api-1 npm test
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Build docker stack
         run: docker-compose build
 
+      - name: List docker images
+        run: docker images ls
+
       - name: Export docker images
         run: |
           docker export -o /tmp/bmore-responsive_api.tar bmore-responsive_api:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,8 @@ jobs:
 
       - name: Export docker images
         run: |
-          docker export bmore-responsive_api > /tmp/bmore-responsive_api.tar
-          docker export bmore-responsive_db > /tmp/bmore-responsive_db.tar
+          docker export bmore-responsive_api:latest -o /tmp/bmore-responsive_api.tar bmore-responsive_api:latest
+          docker export bmore-responsive_db:latest -o /tmp/bmore-responsive_db.tar bmore-responsive_db:latest
 
       - name: Cache API docker image
         uses: actions/upload-artifact@v2
@@ -91,8 +91,8 @@ jobs:
 
       - name: Extract docker images
         run: |
-          docker load --input /tmp/bmore-responsive_api.tar
-          docker load --input /tmp/bmore-responsive_db.tar
+          docker load -i /tmp/bmore-responsive_api.tar
+          docker load -i /tmp/bmore-responsive_db.tar
 
       - name: Compose docker images
         run: docker compose up -d

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,10 +74,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build docker stack
-        run: docker-compose build
-
-      - name: List docker images
-        run: docker images
+        run: docker-compose up -d --build
 
       - name: Save docker images
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,23 +35,23 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    # needs: audit
+    needs: audit
 
     steps:
       - uses: actions/checkout@v2
 
-      # - name: Cache node modules
-      #   uses: actions/cache@v2
-      #   env:
-      #     cache-name: cache-node-modules
-      #   with:
-      #     # npm cache files are stored in `~/.npm` on Linux/macOS
-      #     path: ~/.npm
-      #     key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-build-${{ env.cache-name }}-
-      #       ${{ runner.os }}-build-
-      #       ${{ runner.os }}-
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
 
       - name: install eslint
         run: npm install eslint
@@ -68,7 +68,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    # needs: lint
+    needs: lint
 
     steps:
       - uses: actions/checkout@v2
@@ -110,6 +110,6 @@ jobs:
 
       - name: Test
         run: |
-          docker exec bmore-responsive_api_1 npm test
+          docker exec bmore-responsive-api-1 npm test
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,6 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    container: ${{ env.docker_name }}
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Test
         run: |
-          sleep 15 # wait for containers to set up
+          sleep 10 # wait for containers to set up
           docker exec bmore-responsive-api-1 npm test
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,25 +39,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Cache node modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-node-modules
-        with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+      - name: install eslint
+        run: npm install eslint
 
       - name: Lint JS
         run: npm run lint
 
+      - name: install hadolint
+        run: docker pull hadolint/hadolint
+
       - name: Lint Dockerfile
         run: |
-          docker pull hadolint/hadolint
           docker run --rm -i hadolint/hadolint < Dockerfile
 
   build:
@@ -88,6 +80,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    needs: build
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,10 +76,13 @@ jobs:
       - name: Build docker stack
         run: docker-compose up -d --build
 
+      - name: Show running images
+        run: docker ps
+
       - name: Save docker images
         run: |
-          docker save -o /tmp/bmore-responsive_api.tar bmore-responsive_api:latest
-          docker save -o /tmp/bmore-responsive_db.tar bmore-responsive_db:latest
+          docker export -o /tmp/bmore-responsive_api.tar bmore-responsive_api-1:latest
+          docker export -o /tmp/bmore-responsive_db.tar bmore-responsive_db-1:latest
 
       - name: Cache API docker image
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,16 @@
 name: Bmore Responsive CI
+
 on: push
+
+env:
+  NODE_ENV: development
+  DATABASE_PASSWORD: password
+  JWT_KEY: fortestsonly
+
 jobs:
-  build:
+  npm_install:
     runs-on: ubuntu-latest
-    env:
-      NODE_ENV: development
-      DATABASE_PASSWORD: password
-      JWT_KEY: fortestsonly
+
     steps:
       - uses: actions/checkout@v2
 
@@ -26,11 +30,80 @@ jobs:
       - name: Install npm packages
         run: npm install
 
-      - name: Build docker stack
-        run: docker-compose up -d --build
+      # - name: Audit npm packages
+      #   run: npm audit
 
-      - name: Lint
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Lint JS
         run: npm run lint
+
+      - name: Lint Dockerfile
+        run: |
+          docker pull hadolint/hadolint
+          docker run --rm -i hadolint/hadolint < Dockerfile
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build docker stack
+        run: docker-compose build
+
+      - name: Export docker images
+        run: |
+          docker export bmore-responsive_api > /tmp/bmore-responsive_api.tar
+          docker export bmore-responsive_db > /tmp/bmore-responsive_db.tar
+
+      - name: Cache API docker image
+        uses: actions/upload-artifact@v2
+        with:
+          name: bmore-responsive_api
+          path: /tmp/bmore-responsive_api.tar
+
+      - name: Cache DB docker image
+        uses: actions/upload-artifact@v2
+        with:
+          name: bmore-responsive_db
+          path: /tmp/bmore-responsive_db.tar
+
+  test:
+    runs-on: ubuntu-latest
+    container: ${{ env.docker_name }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download docker images
+        uses: actions/download-artifact@v3
+        with:
+          path: /tmp
+
+      - name: Extract docker images
+        run: |
+          docker load --input /tmp/bmore-responsive_api.tar
+          docker load --input /tmp/bmore-responsive_db.tar
+
+      - name: Compose docker images
+        run: docker compose up -d
 
       - name: Test
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,24 +77,17 @@ jobs:
         run: docker-compose up -d --build
 
       - name: Show running images
-        run: docker ps
+        run: docker images
 
       - name: Save docker images
         run: |
-          docker export -o /tmp/bmore-responsive_api.tar bmore-responsive_api-1:latest
-          docker export -o /tmp/bmore-responsive_db.tar bmore-responsive_db-1:latest
+          docker save -o /tmp/containers.tar bmore-responsive_api:latest postgres:latest
 
       - name: Cache API docker image
         uses: actions/upload-artifact@v2
         with:
-          name: bmore-responsive_api
-          path: /tmp/bmore-responsive_api.tar
-
-      - name: Cache DB docker image
-        uses: actions/upload-artifact@v2
-        with:
-          name: bmore-responsive_db
-          path: /tmp/bmore-responsive_db.tar
+          name: containers
+          path: /tmp/containers.tar
 
   test:
     runs-on: ubuntu-latest
@@ -105,12 +98,12 @@ jobs:
       - name: Download docker images
         uses: actions/download-artifact@v3
         with:
-          path: /tmp
+          name: containers
+          path: /tmp/containers.tar
 
       - name: Extract docker images
         run: |
-          docker load -i /tmp/bmore-responsive_api.tar
-          docker load -i /tmp/bmore-responsive_db.tar
+          docker load -i /tmp/containers.tar
 
       - name: Compose docker images
         run: docker compose up -d

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         run: docker-compose build
 
       - name: List docker images
-        run: docker images ls
+        run: docker images
 
       - name: Export docker images
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: containers
-          path: /tmp/containers.tar
+          path: /tmp
 
       - name: Extract docker images
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ on: push
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      NODE_ENV: development
+      DATABASE_PASSWORD: password
+      JWT_KEY: fortestsonly
     steps:
       - uses: actions/checkout@v2
 
@@ -19,8 +23,8 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
 
-      - name: Install Dependencies
-        run: npm install
+      - name: Build docker stack
+        run: docker-compose up -d --build
 
       - name: Lint
         run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,8 @@ jobs:
 
       - name: Export docker images
         run: |
-          docker export bmore-responsive_api:latest -o /tmp/bmore-responsive_api.tar bmore-responsive_api:latest
-          docker export bmore-responsive_db:latest -o /tmp/bmore-responsive_db.tar bmore-responsive_db:latest
+          docker export -o /tmp/bmore-responsive_api.tar bmore-responsive_api:latest
+          docker export -o /tmp/bmore-responsive_db.tar bmore-responsive_db:latest
 
       - name: Cache API docker image
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
 
+      - name: Install npm packages
+        run: npm install
+
       - name: Build docker stack
         run: docker-compose up -d --build
 
@@ -30,6 +33,7 @@ jobs:
         run: npm run lint
 
       - name: Test
-        run: npm test
+        run: |
+          docker exec bmore-responsive-api-1 npm test
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
   JWT_KEY: fortestsonly
 
 jobs:
-  npm_install:
+  audit:
     runs-on: ubuntu-latest
 
     steps:
@@ -35,9 +35,23 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    # needs: audit
 
     steps:
       - uses: actions/checkout@v2
+
+      # - name: Cache node modules
+      #   uses: actions/cache@v2
+      #   env:
+      #     cache-name: cache-node-modules
+      #   with:
+      #     # npm cache files are stored in `~/.npm` on Linux/macOS
+      #     path: ~/.npm
+      #     key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-build-${{ env.cache-name }}-
+      #       ${{ runner.os }}-build-
+      #       ${{ runner.os }}-
 
       - name: install eslint
         run: npm install eslint
@@ -54,6 +68,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    # needs: lint
 
     steps:
       - uses: actions/checkout@v2
@@ -64,10 +79,10 @@ jobs:
       - name: List docker images
         run: docker images
 
-      - name: Export docker images
+      - name: Save docker images
         run: |
-          docker export -o /tmp/bmore-responsive_api.tar bmore-responsive_api:latest
-          docker export -o /tmp/bmore-responsive_db.tar bmore-responsive_db:latest
+          docker save -o /tmp/bmore-responsive_api.tar bmore-responsive_api:latest
+          docker save -o /tmp/bmore-responsive_db.tar bmore-responsive_db:latest
 
       - name: Cache API docker image
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
# Description

Create CI Pipeline with Github actions that lints, builds and installs.  
## Deploy Notes

Have commented-out code for auditing but do not want to make it live yet as npm is reporting our project having 60 vulnerabilities.  I wanted to set up this pipeline first before installing new versions of packages and see if any of them break our tests after upgrading.  I will create a future pull request that implements auditing.

## TODO
- [ ] Add this as check before merging instead of TravisCI

## Steps to Test or Reproduce

```
Push to any branch and it will automatically run under the 'Actions' tab.
```